### PR TITLE
Update Toolchains.md

### DIFF
--- a/Toolchains.md
+++ b/Toolchains.md
@@ -78,11 +78,11 @@ settings](http://llvm.org/docs/CMake.html).
 
     mkdir llvm && cd llvm
 
-    git clone http://llvm.org/git/llvm.git llvm-src
+    git clone https://github.com/llvm-mirror/llvm.git llvm-src
     cd llvm-src
     git checkout -b v6.0 646a736e7b4
     cd tools
-    git clone http://llvm.org/git/clang.git
+    git clone https://github.com/llvm-mirror/clang.git
     cd clang
     git checkout -b v6.0 bfc08965af
 


### PR DESCRIPTION
## Context of this PR
The repository of LLVM moved to GitHub https://github.com/llvm/llvm-project.git. The right repository is now hosted on https://github.com/llvm-mirror/llvm.

The repository of clang also moved.

## Summary of changes
- Update the repository URLs